### PR TITLE
refactor: Prepare code for inclusion for sycnhrnous entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Alternatively, the `H2O_CLOUD_ENVIRONMENT` environment variable can be used.
 ```python
 import h2o_discovery
 
-discovery = await h2o_discovery.discover()
+discovery = await h2o_discovery.discover_async()
 
 # Print the H2O Cloud environment that was discovered.
 print(discovery.environment.h2o_cloud_environment)
@@ -47,7 +47,7 @@ from h2o_wave import main
 
 @app("/")
 async def serve(q: Q):
-    discovery = await h2o_discovery.discover()
+    discovery = await h2o_discovery.discover_async()
 
     token_provider = h2o_authn.AsyncTokenProvider(
         refresh_token=q.auth.refresh_token,

--- a/src/h2o_discovery/__init__.py
+++ b/src/h2o_discovery/__init__.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
+from h2o_discovery import async_client
 from h2o_discovery import discovery
 from h2o_discovery import lookup
-from h2o_discovery import client
 
 from h2o_discovery._version import __version__  # noqa: F401
 
@@ -10,7 +10,7 @@ from h2o_discovery._version import __version__  # noqa: F401
 Discovery = discovery.Discovery
 
 
-async def discover(
+async def discover_async(
     environment: Optional[str] = None, discovery_address: Optional[str] = None
 ) -> Discovery:
     """Obtains and returns a Discovery object from the discovery service.
@@ -25,5 +25,5 @@ async def discover(
 
     """
     uri = lookup.determine_uri(environment, discovery_address)
-    cl = client.Client(uri)
-    return await Discovery.load(cl)
+    cl = async_client.AsyncClient(uri)
+    return await Discovery.load_async(cl)

--- a/src/h2o_discovery/async_client.py
+++ b/src/h2o_discovery/async_client.py
@@ -1,0 +1,75 @@
+from typing import List
+from typing import Optional
+
+import httpx
+
+from h2o_discovery import model
+from h2o_discovery import client
+
+
+class AsyncClient:
+    """Asynchronous Implementation of the Discovery Service API.
+
+    Listing methods do pagination and always return all of the available objects.
+    """
+
+    def __init__(self, uri: str):
+        self._uri = uri
+
+        self._environment_uri = client.get_environment_uri(uri)
+        self._services_uri = client.get_services_uri(uri)
+        self._clients_uri = client.get_clients_uri(uri)
+
+    async def get_environment(self) -> model.Environment:
+        """Returns the information about the environment."""
+        async with httpx.AsyncClient() as client:
+            resp = await _fetch(client, self._environment_uri)
+            return model.Environment.from_json_dict(resp.json()["environment"])
+
+    async def list_services(self) -> List[model.Service]:
+        """Returns the list of all registered services."""
+        async with httpx.AsyncClient() as client:
+            services: List[model.Service] = []
+
+            pages = await _get_all_pages(client, self._services_uri)
+            for page in pages:
+                services.extend(
+                    [model.Service.from_json_dict(d) for d in page.get("services", [])]
+                )
+            return services
+
+    async def list_clients(self) -> List[model.Client]:
+        """Returns the list of all registered clients."""
+        async with httpx.AsyncClient() as client:
+            clients: List[model.Client] = []
+
+            pages = await _get_all_pages(client, self._clients_uri)
+            for page in pages:
+                clients.extend(
+                    [model.Client.from_json_dict(d) for d in page.get("clients", [])]
+                )
+            return clients
+
+
+async def _fetch(
+    client: httpx.AsyncClient, uri: str, next_page_token: Optional[str] = None
+) -> httpx.Response:
+    params = None
+    if next_page_token is not None:
+        params = {"pageToken": next_page_token}
+    resp = await client.get(uri, params=params)
+    resp.raise_for_status()
+    return resp
+
+
+async def _get_all_pages(client: httpx.AsyncClient, uri: str) -> List[dict]:
+    next_page_token: Optional[str] = None
+    all_pages: List[dict] = []
+
+    while True:
+        resp = await _fetch(client, uri, next_page_token)
+        resp_json = resp.json()
+        all_pages.append(resp_json)
+        next_page_token = resp_json.get("nextPageToken")
+        if next_page_token is None:
+            return all_pages

--- a/src/h2o_discovery/client.py
+++ b/src/h2o_discovery/client.py
@@ -1,70 +1,18 @@
-from typing import List
-from typing import Optional
-
-import httpx
-
-from h2o_discovery import model
+import urllib.parse
 
 
-class Client:
-    """Implementation of the Discovery Service API.
-
-    Listing methods do pagination and always return all of the available objects.
-    """
-
-    def __init__(self, uri: str):
-        self._uri = uri
-
-    async def get_environment(self) -> model.Environment:
-        """Returns the information about the environment."""
-        async with httpx.AsyncClient() as client:
-            resp = await _fetch(client, self._uri + "/v1/environment")
-            return model.Environment.from_json_dict(resp.json()["environment"])
-
-    async def list_services(self) -> List[model.Service]:
-        """Returns the list of all registered services."""
-        async with httpx.AsyncClient() as client:
-            services: List[model.Service] = []
-
-            pages = await _get_all_pages(client, self._uri + "/v1/services")
-            for page in pages:
-                services.extend(
-                    [model.Service.from_json_dict(d) for d in page.get("services", [])]
-                )
-            return services
-
-    async def list_clients(self) -> List[model.Client]:
-        """Returns the list of all registered clients."""
-        async with httpx.AsyncClient() as client:
-            clients: List[model.Client] = []
-
-            pages = await _get_all_pages(client, self._uri + "/v1/clients")
-            for page in pages:
-                clients.extend(
-                    [model.Client.from_json_dict(d) for d in page.get("clients", [])]
-                )
-            return clients
+ENVIRONMENT_ENDPOINT = "/v1/environment"
+SERVICES_ENDPOINT = "/v1/services"
+CLIENTS_ENDPOINT = "/v1/clients"
 
 
-async def _fetch(
-    client: httpx.AsyncClient, uri: str, next_page_token: Optional[str] = None
-) -> httpx.Response:
-    params = None
-    if next_page_token is not None:
-        params = {"pageToken": next_page_token}
-    resp = await client.get(uri, params=params)
-    resp.raise_for_status()
-    return resp
+def get_environment_uri(uri: str) -> str:
+    return urllib.parse.urljoin(uri, ENVIRONMENT_ENDPOINT)
 
 
-async def _get_all_pages(client: httpx.AsyncClient, uri: str) -> List[dict]:
-    next_page_token: Optional[str] = None
-    all_pages: List[dict] = []
+def get_services_uri(uri: str) -> str:
+    return urllib.parse.urljoin(uri, SERVICES_ENDPOINT)
 
-    while True:
-        resp = await _fetch(client, uri, next_page_token)
-        resp_json = resp.json()
-        all_pages.append(resp_json)
-        next_page_token = resp_json.get("nextPageToken")
-        if next_page_token is None:
-            return all_pages
+
+def get_clients_uri(uri: str) -> str:
+    return urllib.parse.urljoin(uri, CLIENTS_ENDPOINT)

--- a/src/h2o_discovery/discovery.py
+++ b/src/h2o_discovery/discovery.py
@@ -1,9 +1,10 @@
 import dataclasses
 import types
+from typing import Iterable
 from typing import Mapping
 
+from h2o_discovery import async_client
 from h2o_discovery import model
-from h2o_discovery import client
 
 
 @dataclasses.dataclass(frozen=True)
@@ -20,25 +21,25 @@ class Discovery:
     clients: Mapping[str, model.Client]
 
     @classmethod
-    async def load(cls, cl: client.Client) -> "Discovery":
+    async def load_async(cls, cl: async_client.AsyncClient) -> "Discovery":
         """Loads the discovery records from the Discovery Service."""
         environment = await cl.get_environment()
-        services = await _get_service_map(cl)
-        clients = await _get_client_map(cl)
+        services = _get_service_map(await cl.list_services())
+        clients = _get_client_map(await cl.list_clients())
 
         return cls(environment=environment, services=services, clients=clients)
 
 
-async def _get_service_map(cl: client.Client) -> Mapping[str, model.Service]:
+def _get_service_map(services: Iterable[model.Service]) -> Mapping[str, model.Service]:
     out = {}
-    for s in await cl.list_services():
+    for s in services:
         out[_service_key(s.name)] = s
     return types.MappingProxyType(out)
 
 
-async def _get_client_map(cl: client.Client) -> Mapping[str, model.Client]:
+def _get_client_map(clients: Iterable[model.Client]) -> Mapping[str, model.Client]:
     out = {}
-    for c in await cl.list_clients():
+    for c in clients:
         out[_client_key(c.name)] = c
     return types.MappingProxyType(out)
 

--- a/tests/e2e/test_clients.py
+++ b/tests/e2e/test_clients.py
@@ -13,9 +13,9 @@ TEST_CLIENT = model.Client(
 
 @pytest.mark.e2e
 @pytest.mark.asyncio
-async def test_clients(discovery_address):
+async def test_clients_async(discovery_address):
     # When
-    discovery = await h2o_discovery.discover(discovery_address=discovery_address)
+    discovery = await h2o_discovery.discover_async(discovery_address=discovery_address)
 
     # Then
     assert discovery.clients["test-client"] == TEST_CLIENT

--- a/tests/e2e/test_environment.py
+++ b/tests/e2e/test_environment.py
@@ -5,13 +5,13 @@ import h2o_discovery
 
 @pytest.mark.e2e
 @pytest.mark.asyncio
-async def test_environment(
+async def test_environment_async(
     discovery_address,
     expected_environment_issuer_url,
     expected_environment_h2o_environment,
 ):
     # When
-    discovery = await h2o_discovery.discover(discovery_address=discovery_address)
+    discovery = await h2o_discovery.discover_async(discovery_address=discovery_address)
 
     # Then
     env = discovery.environment

--- a/tests/e2e/test_services.py
+++ b/tests/e2e/test_services.py
@@ -43,9 +43,11 @@ TEST_SERVICE_ON_INTERNAL = model.Service(
 
 @pytest.mark.e2e
 @pytest.mark.asyncio
-async def test_services_on_public_endpoint(public_discovery_address):
+async def test_services_on_public_endpoint_async(public_discovery_address):
     # When
-    discovery = await h2o_discovery.discover(discovery_address=public_discovery_address)
+    discovery = await h2o_discovery.discover_async(
+        discovery_address=public_discovery_address
+    )
 
     # Then
     services = discovery.services
@@ -57,13 +59,11 @@ async def test_services_on_public_endpoint(public_discovery_address):
 
 @pytest.mark.e2e
 @pytest.mark.asyncio
-async def test_services_on_internal_endpoint(internal_discovery_address):
-    # Given
-    discovery = await h2o_discovery.discover(
+async def test_services_on_internal_endpoint_async(internal_discovery_address):
+    # When
+    discovery = await h2o_discovery.discover_async(
         discovery_address=internal_discovery_address
     )
-
-    # When
 
     # Then
     services = discovery.services

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -2,7 +2,7 @@ import pytest
 import respx
 import httpx
 
-from h2o_discovery import client
+from h2o_discovery import async_client
 from h2o_discovery import model
 
 
@@ -19,7 +19,7 @@ async def test_get_environment():
             }
         }
     )
-    cl = client.Client("https://test.example.com")
+    cl = async_client.AsyncClient("https://test.example.com")
 
     # When
     env = await cl.get_environment()
@@ -87,7 +87,7 @@ async def test_list_services():
         ),
     ]
 
-    cl = client.Client("https://test.example.com")
+    cl = async_client.AsyncClient("https://test.example.com")
 
     # When
     services = await cl.list_services()
@@ -184,7 +184,7 @@ async def test_list_clients():
         ),
     ]
 
-    cl = client.Client("https://test.example.com")
+    cl = async_client.AsyncClient("https://test.example.com")
 
     # When
     clients = await cl.list_clients()
@@ -224,7 +224,7 @@ async def test_list_clients():
 async def test_list_services_can_handle_empty_response():
     # Given
     respx.get("https://test.example.com/v1/services").respond(json={})
-    cl = client.Client("https://test.example.com")
+    cl = async_client.AsyncClient("https://test.example.com")
 
     # When
     services = await cl.list_services()
@@ -238,7 +238,7 @@ async def test_list_services_can_handle_empty_response():
 async def test_list_clients_can_handle_empty_response():
     # Given
     respx.get("https://test.example.com/v1/clients").respond(json={})
-    cl = client.Client("https://test.example.com")
+    cl = async_client.AsyncClient("https://test.example.com")
 
     # When
     services = await cl.list_clients()

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -21,7 +21,7 @@ def mock_client():
 
 
 @pytest.mark.asyncio
-async def test_discovery_environment(mock_client):
+async def test_discovery_environment_async(mock_client):
     # Given
     environment = model.Environment(
         h2o_cloud_environment="https://test.example.com",
@@ -33,14 +33,14 @@ async def test_discovery_environment(mock_client):
     mock_client.get_environment.return_value.set_result(environment)
 
     # When
-    discovery = await h2o_discovery.Discovery.load(mock_client)
+    discovery = await h2o_discovery.Discovery.load_async(mock_client)
 
     # Then
     assert discovery.environment == environment
 
 
 @pytest.mark.asyncio
-async def test_discovery_services(mock_client):
+async def test_discovery_services_async(mock_client):
     # Given
     service = model.Service(
         name="services/test-service",
@@ -55,14 +55,14 @@ async def test_discovery_services(mock_client):
     mock_client.list_services.return_value.set_result([service])
 
     # When
-    discovery = await h2o_discovery.Discovery.load(mock_client)
+    discovery = await h2o_discovery.Discovery.load_async(mock_client)
 
     # Then
     assert discovery.services["test-service"] == service
 
 
 @pytest.mark.asyncio
-async def test_discovery_clients(mock_client):
+async def test_discovery_clients_async(mock_client):
     # Given
     client_record = model.Client(
         name="clients/test-client",
@@ -74,7 +74,7 @@ async def test_discovery_clients(mock_client):
     mock_client.list_clients.return_value.set_result([client_record])
 
     # When
-    discovery = await h2o_discovery.Discovery.load(mock_client)
+    discovery = await h2o_discovery.Discovery.load_async(mock_client)
 
     # Then
     assert discovery.clients["test-client"] == client_record


### PR DESCRIPTION
BREAKING CHANGE: Rename default netrypoint function to `discover_async`.

Voting on https://github.com/h2oai/cloud-discovery/issues/127 decided to have default `discover` as synchronous option.

All of the internal methods and tests are renamed to contain `_async` if there's a chance they get sycnhronous variant. Some pieces of the code are adjusted to allow reuse with synchrnous varaint.

PART OF https://github.com/h2oai/cloud-discovery/issues/127