### PR TITLE
feat: add support for `version` field in the environment

### DIFF
--- a/src/h2o_discovery/model.py
+++ b/src/h2o_discovery/model.py
@@ -88,6 +88,9 @@ class Environment:
     # define its own scope.
     h2o_cloud_platform_oauth2_scope: str
 
+    # Version of the H2O Cloud Platform release that is running in the environment.
+    h2o_cloud_version: Optional[str]
+
     @classmethod
     def from_json_dict(cls, json: Mapping[str, str]) -> "Environment":
         """Create an Environment from a JSON dict returned by the server."""
@@ -95,4 +98,5 @@ class Environment:
             h2o_cloud_environment=json["h2oCloudEnvironment"],
             issuer_url=json["issuerUrl"],
             h2o_cloud_platform_oauth2_scope=json["h2oCloudPlatformOauth2Scope"],
+            h2o_cloud_version=json.get("h2oCloudVersion"),
         )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -275,6 +275,7 @@ ENVIRONMENT_JSON = {
         "h2oCloudEnvironment": "https://cloud.fbi.com",
         "h2oCloudPlatformOauth2Scope": "openid profile email",
         "issuerUrl": "https://phantauth.net",
+        "h2oCloudVersion": "70.25",
     }
 }
 
@@ -282,6 +283,7 @@ EXPECTED_ENVIRONMENT_DATA = model.Environment(
     h2o_cloud_environment="https://cloud.fbi.com",
     h2o_cloud_platform_oauth2_scope="openid profile email",
     issuer_url="https://phantauth.net",
+    h2o_cloud_version="70.25",
 )
 
 SERVICES_RESPONSES = [

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -24,6 +24,7 @@ ENVIRONMENT_DATA = model.Environment(
     h2o_cloud_environment="https://test.example.com",
     h2o_cloud_platform_oauth2_scope="test-scope",
     issuer_url="https://test.example.com",
+    h2o_cloud_version="test-version",
 )
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -51,6 +51,7 @@ def test_environment_from_json_dict():
         "h2oCloudEnvironment": "https://test.h2o.ai",
         "issuerUrl": "https://test.h2o.ai",
         "h2oCloudPlatformOauth2Scope": "test-platform-scope",
+        "h2oCloudVersion": "test-version",
     }
 
     # When
@@ -61,4 +62,25 @@ def test_environment_from_json_dict():
         h2o_cloud_environment="https://test.h2o.ai",
         issuer_url="https://test.h2o.ai",
         h2o_cloud_platform_oauth2_scope="test-platform-scope",
+        h2o_cloud_version="test-version",
+    )
+
+
+def test_environment_from_json_dict_with_missing_version():
+    # Given
+    json = {
+        "h2oCloudEnvironment": "https://test.h2o.ai",
+        "issuerUrl": "https://test.h2o.ai",
+        "h2oCloudPlatformOauth2Scope": "test-platform-scope",
+    }
+
+    # When
+    result = model.Environment.from_json_dict(json)
+
+    # Then
+    assert result == model.Environment(
+        h2o_cloud_environment="https://test.h2o.ai",
+        issuer_url="https://test.h2o.ai",
+        h2o_cloud_platform_oauth2_scope="test-platform-scope",
+        h2o_cloud_version=None,
     )


### PR DESCRIPTION
added field is `Optional` to be compatible with the version of the BE that does not have it.

PART OF https://github.com/h2oai/cloud-discovery/issues/159
FOLLOW UP FOR https://github.com/h2oai/cloud-discovery/pull/160