### PR TITLE
ci: 👷 extract all jobs to reusable worklows

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -1,0 +1,37 @@
+name: Python Build
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        id: setup-python
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install pypa/build
+        run: |
+          python -m pip install build
+
+      - name: Build a binary wheel and a source tarball on Python ${{ matrix.python-version }}
+        run: |
+          python -m build
+
+  all-builds-passed:
+    # Used as aggregate check for all builds being run in matrix.
+    name: All Builds Passed
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "All builds passed!" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -1,0 +1,48 @@
+name: Python Lint
+
+on:
+  workflow_call:
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        id: setup-python
+        with:
+          python-version: "3.10"
+
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cache/pypoetry
+          key: ${{ runner.os }}-poetry-test-${{ steps.setup-python.outputs.python-version }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-poetry-lint-${{ steps.setup-python.outputs.python-version }}-
+            ${{ runner.os }}-poetry-lint-
+            ${{ runner.os }}-poetry
+
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-lint-${{ steps.setup-python.outputs.python-version }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-pip-lint-${{ steps.setup-python.outputs.python-version }}-
+            ${{ runner.os }}-pip-lint-
+            ${{ runner.os }}-pip
+
+      - name: Install nox
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install poetry==1.2.2
+
+          poetry export --format=constraints.txt --with dev --without-hashes \
+          | pip install --constraint=/dev/stdin nox nox-poetry
+
+      - name: Run Linters
+        run: |
+          nox -s lint

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -1,4 +1,5 @@
 name: Python Test
+
 on:
   workflow_call:
 
@@ -50,3 +51,11 @@ jobs:
           PYTHON_VERSION: ${{ matrix.python-version }}
         run: |
           nox -s tests -p ${PYTHON_VERSION%-*} -- -v
+
+  all-tests-passed:
+    # Used as aggregate check for all tests being run in matrix.
+    name: All Tests Passed
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "All tests passed!" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -3,9 +3,11 @@ name: Python
 on:
   push:
     branches: [main]
+
   pull_request:
     paths-ignore:
-      - '**.md'
+      - "**.md"
+
 jobs:
   test:
     name: Test
@@ -13,68 +15,8 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        id: setup-python
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install pypa/build
-        run: |
-          python -m pip install build
-
-      - name: Build a binary wheel and a source tarball
-        run: |
-          python -m build
-
+    uses: ./.github/workflows/python-build.yml
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        id: setup-python
-        with:
-          python-version: "3.10"
-
-      - uses: actions/cache@v3
-        with:
-          path: ~/.cache/pypoetry
-          key: ${{ runner.os }}-poetry-test-${{ steps.setup-python.outputs.python-version }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-poetry-lint-${{ steps.setup-python.outputs.python-version }}-
-            ${{ runner.os }}-poetry-lint-
-            ${{ runner.os }}-poetry
-
-      - uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-lint-${{ steps.setup-python.outputs.python-version }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-pip-lint-${{ steps.setup-python.outputs.python-version }}-
-            ${{ runner.os }}-pip-lint-
-            ${{ runner.os }}-pip
-
-      - name: Install nox
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install poetry==1.2.2
-
-          poetry export --format=constraints.txt --with dev --without-hashes \
-          | pip install --constraint=/dev/stdin nox nox-poetry
-
-      - name: Run Linters
-        run: |
-          nox -s lint
+    uses: ./.github/workflows/python-lint.yml


### PR DESCRIPTION
- run all of the jobs in the main Python wokflow as reusable workflows
- add aggregate job for both build and test workflows so that we can see the status of the whole workflow in the PR checks
