### PR TITLE
chore: 🧑‍💻 add `devtest` environment for quick development tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,33 @@ async def serve(q: Q):
     ...
 
 ```
+
+## Development
+
+Project is managed using [Hatch](https://hatch.pypa.io/latest/).
+
+### Testing
+
+For quick development tests use :
+
+```sh
+hatch run devtest:pytest
+```
+
+Full test matrix can be run using:
+
+```sh
+hatch env remove test && hatch run test:pytest
+```
+
+### Linting
+
+```sh
+hatch run lint:check
+```
+
+Formating and imports can be fixed using:
+
+```sh
+hatch run lint:fix
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,10 @@ dev-mode = false
 [tool.hatch.envs.test.scripts]
 pytest = "python -m pytest {args}"
 
+[tool.hatch.envs.devtest]
+template = "test"
+dev-mode = true
+
 [tool.hatch.envs.lint]
 dependencies = [
   "black==22.10.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ fix = [
 
 [tool.hatch.envs.docs]
 dependencies = [
-  "pydoc-markdown==4.6.4",
+  "pydoc-markdown==4.8.2",
 ]
 
 [tool.hatch.envs.docs.scripts]

--- a/tests/_internal/lookup/test_determine_uri.py
+++ b/tests/_internal/lookup/test_determine_uri.py
@@ -66,7 +66,7 @@ def discovery_test_cases():
 
 
 @pytest.mark.parametrize("environment_input,expected_uri", environment_test_cases())
-def test_find_uri_environment_param(environment_input, expected_uri):
+def test_determine_uri_environment_param(environment_input, expected_uri):
     # When
     uri = lookup.determine_uri(environment=environment_input)
 
@@ -75,7 +75,9 @@ def test_find_uri_environment_param(environment_input, expected_uri):
 
 
 @pytest.mark.parametrize("environment_input,expected_uri", environment_test_cases())
-def test_find_uri_environment_env_var(monkeypatch, environment_input, expected_uri):
+def test_determine_uri_environment_env_var(
+    monkeypatch, environment_input, expected_uri
+):
     # Given
     monkeypatch.setenv("H2O_CLOUD_ENVIRONMENT", environment_input)
 
@@ -87,7 +89,7 @@ def test_find_uri_environment_env_var(monkeypatch, environment_input, expected_u
 
 
 @pytest.mark.parametrize("discovery_input,expected_uri", discovery_test_cases())
-def test_find_uri_discovery_param(discovery_input, expected_uri):
+def test_determine_uri_discovery_param(discovery_input, expected_uri):
     # When
     uri = lookup.determine_uri(discovery_address=discovery_input)
 
@@ -96,7 +98,7 @@ def test_find_uri_discovery_param(discovery_input, expected_uri):
 
 
 @pytest.mark.parametrize("discovery_input,expected_uri", discovery_test_cases())
-def test_find_uri_discovery_env_var(monkeypatch, discovery_input, expected_uri):
+def test_determine_uri_discovery_env_var(monkeypatch, discovery_input, expected_uri):
     # Given
     monkeypatch.setenv("H2O_CLOUD_DISCOVERY", discovery_input)
 
@@ -107,7 +109,7 @@ def test_find_uri_discovery_env_var(monkeypatch, discovery_input, expected_uri):
     assert uri == expected_uri
 
 
-def test_find_uri_both_env_var_discovery_takes_precedence(monkeypatch):
+def test_determine_uri_both_env_var_discovery_takes_precedence(monkeypatch):
     # Given
     monkeypatch.setenv("H2O_CLOUD_ENVIRONMENT", "https://test.h2o.ai")
     monkeypatch.setenv("H2O_CLOUD_DISCOVERY", "http://test-service.domain:1234")
@@ -119,7 +121,8 @@ def test_find_uri_both_env_var_discovery_takes_precedence(monkeypatch):
     assert uri == "http://test-service.domain:1234"
 
 
-def test_find_uri_environment_param_takes_precedence(monkeypatch):
+
+def test_determine_uri_environment_param_takes_precedence(monkeypatch):
     # Given
     monkeypatch.setenv("H2O_CLOUD_ENVIRONMENT", "https://test-env.h2o.ai")
     environment = "https://test-param.h2o.ai"
@@ -131,7 +134,7 @@ def test_find_uri_environment_param_takes_precedence(monkeypatch):
     assert uri == "https://test-param.h2o.ai/.ai.h2o.cloud.discovery"
 
 
-def test_find_uri_discovery_param_takes_precedence(monkeypatch):
+def test_determine_uri_discovery_param_takes_precedence(monkeypatch):
     # Given
     monkeypatch.setenv("H2O_CLOUD_DISCOVERY", "http://test-env.domain:1234")
     discovery = "http://test-param.domain:1234"
@@ -143,7 +146,7 @@ def test_find_uri_discovery_param_takes_precedence(monkeypatch):
     assert uri == "http://test-param.domain:1234"
 
 
-def test_find_uri_environment_param_takes_precedence_over_discovery_env_var(
+def test_determine_uri_environment_param_takes_precedence_over_discovery_env_var(
     monkeypatch,
 ):
     # Given
@@ -157,7 +160,7 @@ def test_find_uri_environment_param_takes_precedence_over_discovery_env_var(
     assert uri == "https://test-param.h2o.ai/.ai.h2o.cloud.discovery"
 
 
-def test_find_cannot_set_both_params():
+def test_determine_uri_cannot_set_both_params():
     # Given
     environment = "https://test.h2o.ai"
     discovery = "http://test-service.domain:1234"
@@ -170,7 +173,7 @@ def test_find_cannot_set_both_params():
     assert "cannot specify both discovery and environment" in str(excinfo.value)
 
 
-def test_find_cannot_determine_url():
+def test_determine_uri_cannot_determine_url():
     # Given
     environment = None
     discovery = None


### PR DESCRIPTION
Current `test` environment has matrix for `httpx` and `python` versions and tests against packaged version of the project to verify the build result.
This is overkill for local cevelopment sanity checks. Hatch does not update the project when there are changes to the sources so `dev-mode = false` `hatch env remove` is neeede with `test` ro verify changes.
