### PR TITLE
chore: 🧑‍💻 add `devtest` environment for quick development tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Project is managed using [Hatch](https://hatch.pypa.io/latest/).
 
 ### Testing
 
-For quick development tests use :
+For quick development tests use:
 
 ```sh
 hatch run devtest:pytest

--- a/README.md
+++ b/README.md
@@ -64,3 +64,33 @@ async def serve(q: Q):
     ...
 
 ```
+
+## Development
+
+Project is managed using [Hatch](https://hatch.pypa.io/latest/).
+
+### Testing
+
+For quick development tests use :
+
+```sh
+hatch run devtest:pytest
+```
+
+Full test matrix can be run using:
+
+```sh
+hatch env remove test && hatch run test:pytest
+```
+
+### Linting
+
+```sh
+hatch run lint:check
+```
+
+Formating and imports can be fixed using:
+
+```sh
+hatch run lint:fix
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,10 @@ dev-mode = false
 [tool.hatch.envs.test.scripts]
 pytest = "python -m pytest {args}"
 
+[tool.hatch.envs.devtest]
+template = "test"
+dev-mode = true
+
 [tool.hatch.envs.lint]
 dependencies = [
   "black==22.10.0",


### PR DESCRIPTION
Current `test` environment has matrix for `httpx` and `python` versions and tests against packaged version of the project to verify the build result.
This is overkill for local cevelopment sanity checks. Hatch does not update the project when there are changes to the sources so `dev-mode = false` `hatch env remove` is neeede with `test` ro verify changes.
