### PR TITLE
ci: 👷 update snyk workflows

### DIFF
--- a/.github/workflows/snyk-monitor.yaml
+++ b/.github/workflows/snyk-monitor.yaml
@@ -4,13 +4,15 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - 'v*'
+      - "v*"
     branches:
       - main
+  schedule:
+    - cron: "30 5 * * 1,3,5"
 
 env:
   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-  PYTHON_VERSION: '3.10'
+  PYTHON_VERSION: "3.10"
 
 jobs:
   snyk_scan_monitor:
@@ -27,10 +29,10 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-        
+
       - name: Monitor python dependencies
         env:
-          SNYK_TOKEN: '${{ secrets.SNYK_TOKEN }}'
+          SNYK_TOKEN: "${{ secrets.SNYK_TOKEN }}"
         run: |
           PYTHON=python${{ env.PYTHON_VERSION }}
           $PYTHON -m pip install .

--- a/.github/workflows/snyk-test.yaml
+++ b/.github/workflows/snyk-test.yaml
@@ -3,15 +3,20 @@ name: Snyk Test
 on:
   pull_request:
     paths:
-      - 'pyproject.toml'
-  
+      - "pyproject.toml"
+      - ".github/workflows/snyk-test.yml"
+
 env:
   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-  PYTHON_VERSION: '3.10'
+  PYTHON_VERSION: "3.10"
 
 jobs:
   snyk_scan_test:
     runs-on: ubuntu-latest
+
+    # Don't try to scan for dependabot PRs.
+    if: github.actor != 'dependabot[bot]'
+
     steps:
       - uses: actions/checkout@v3
       - uses: snyk/actions/setup@master
@@ -27,6 +32,7 @@ jobs:
           $PYTHON -m pip freeze > requirements.txt
           snyk test \
             -d \
+            --fail-on=all \
             --file=requirements.txt \
             --command=$PYTHON \
             --skip-unresolved


### PR DESCRIPTION
 - skip test for dependabot PRs
   - dependabot does not have access to SNYK_TOKEN
- add `--fail-on=all ` so that test does not fail on issues that cannot be fixed
 - add schedule for the monitor so that issues caused by transient dependencies can fix themselves automaticaly as we do no lock verisons being a library
 - remove whitespaces
 - format using GHA formatter (unifies quote signs)
