### PR TITLE
feat: ✨ add support for reading endpoint from the local H2O CLI configuration file

### DIFF
--- a/src/h2o_discovery/__init__.py
+++ b/src/h2o_discovery/__init__.py
@@ -1,6 +1,7 @@
 import dataclasses
 import os
 from typing import Optional
+from typing import Tuple
 from typing import Union
 
 from h2o_discovery import model
@@ -25,6 +26,7 @@ def discover(
         - H2O_CLOUD_DISCOVERY environment variable
         - environment parameter
         - H2O_CLOUD_ENVIRONMENT environment variable
+        - environment URI loaded from the local H2O CLI configuration file
 
     Config path is determined with the following precedence:
         - config_path parameter
@@ -35,14 +37,12 @@ def discover(
     Args:
         environment: The H2O Cloud environment URL to use (e.g. https://cloud.h2o.ai).
         discovery_address: The address of the discovery service.
-        config_path: The path to the H2O CLI configuration file. Only used for
-            credentials lookup.
+        config_path: The path to the H2O CLI configuration file.
 
     Raises:
         LookupError: If the URI cannot be determined.
     """
-    uri = lookup.determine_uri(environment, discovery_address)
-    cfg = config.load_config(lookup.determine_local_config_path(config_path))
+    uri, cfg = _lookup_and_load(environment, discovery_address, config_path)
 
     discovery = load.load_discovery(client.Client(uri))
     credentials = load.load_credentials(
@@ -64,6 +64,7 @@ async def discover_async(
         - H2O_CLOUD_DISCOVERY environment variable
         - environment parameter
         - H2O_CLOUD_ENVIRONMENT environment variable
+        - environment URI loaded from the local H2O CLI configuration file
 
     Config path is determined with the following precedence:
         - config_path parameter
@@ -74,15 +75,13 @@ async def discover_async(
     Args:
         environment: The H2O Cloud environment URL to use (e.g. https://cloud.h2o.ai).
         discovery_address: The address of the discovery service.
-        config_path: The path to the H2O CLI configuration file. Only used for
-            credentials lookup.
+        config_path: The path to the H2O CLI configuration file.
 
     Raises:
         LookupError: If the URI cannot be determined.
     """
 
-    uri = lookup.determine_uri(environment, discovery_address)
-    cfg = config.load_config(lookup.determine_local_config_path(config_path))
+    uri, cfg = _lookup_and_load(environment, discovery_address, config_path)
 
     discovery = await load.load_discovery_async(client.AsyncClient(uri))
     credentials = load.load_credentials(
@@ -90,3 +89,25 @@ async def discover_async(
     )
 
     return dataclasses.replace(discovery, credentials=credentials)
+
+
+def _lookup_and_load(
+    environment: Optional[str] = None,
+    discovery_address: Optional[str] = None,
+    config_path: Optional[Union[str, bytes, os.PathLike]] = None,
+) -> Tuple[str, config.Config]:
+    cfg = config.load_config(lookup.determine_local_config_path(config_path))
+
+    try:
+        uri = lookup.determine_uri(environment, discovery_address, cfg.endpoint)
+    except lookup.DetermineURIError:
+        raise LookupError(
+            "Cannot determine discovery URI."
+            " Please set H2O_CLOUD_ENVIRONMENT or H2O_CLOUD_DISCOVERY environment"
+            " variables or use the environment or discovery parameters."
+            " Alternatively, you can create configure your local environment with"
+            " the with H2O CLI with and/or use H2OCONFIG environment variable"
+            " (see https://docs.h2o.ai/h2o-ai-cloud/developerguide/cli)."
+        )
+
+    return uri, cfg

--- a/src/h2o_discovery/_internal/config.py
+++ b/src/h2o_discovery/_internal/config.py
@@ -14,6 +14,9 @@ def _empty_tokens_factory() -> Mapping[str, str]:
 class Config:
     """Internal representation of the H2O CLI Configuration."""
 
+    #: Configured URI of environment.
+    endpoint: Optional[str] = None
+
     #: Map of found tokens in the configuration file. in the `{"client-id": "token"}`
     #: format.
     tokens: Mapping[str, str] = dataclasses.field(default_factory=_empty_tokens_factory)
@@ -31,6 +34,7 @@ def load_config(path: Optional[str] = None) -> Config:
     with open(path, "rb") as f:
         data = tomllib.load(f)
 
+    endpoint = data.get("Endpoint")
     client_id = data.get("ClientID")
     token = data.get("Token")
     platform_client_id = data.get("PlatformClientID")
@@ -42,4 +46,4 @@ def load_config(path: Optional[str] = None) -> Config:
     if platform_client_id is not None and platform_token is not None:
         tokens[platform_client_id] = platform_token
 
-    return Config(tokens=types.MappingProxyType(tokens))
+    return Config(endpoint=endpoint, tokens=types.MappingProxyType(tokens))

--- a/src/h2o_discovery/_internal/lookup.py
+++ b/src/h2o_discovery/_internal/lookup.py
@@ -7,8 +7,14 @@ _WELL_KNOWN_PATH = ".ai.h2o.cloud.discovery"
 _DEFAULT_LOCAL_CONFIG_PATH = "~/.h2oai/h2o-cli-config.toml"
 
 
+class DetermineURIError(LookupError):
+    """Raised when the discovery endpoint cannot be determined."""
+
+
 def determine_uri(
-    environment: Optional[str] = None, discovery_address: Optional[str] = None
+    environment: Optional[str] = None,
+    discovery_address: Optional[str] = None,
+    config_endpoint: Optional[str] = None,
 ) -> str:
     """Uses passed parameters and environment variables to get the uri of the discovery
     service.
@@ -30,11 +36,10 @@ def determine_uri(
     if environment is not None:
         return _discovery_uri_from_environment(environment)
 
-    raise LookupError(
-        "Cannot determine discovery URI."
-        " Please set H2O_CLOUD_ENVIRONMENT or H2O_CLOUD_DISCOVERY environment variables"
-        "or use the environment or discovery parameters."
-    )
+    if config_endpoint is not None:
+        return _discovery_uri_from_environment(config_endpoint)
+
+    raise DetermineURIError
 
 
 def _discovery_uri_from_environment(environment: str):
@@ -52,7 +57,7 @@ def determine_local_config_path(
 
     config_path = os.environ.get("H2OCONFIG")
     if config_path is not None:
-        return config_path
+        return os.fspath(config_path)
 
     local_config_path = os.path.expanduser(_DEFAULT_LOCAL_CONFIG_PATH)
     if not os.path.isfile(local_config_path):

--- a/tests/_internal/lookup/test_determine_uri.py
+++ b/tests/_internal/lookup/test_determine_uri.py
@@ -177,9 +177,6 @@ def test_determine_uri_cannot_determine_url():
     environment = None
     discovery = None
 
-    # When
-    with pytest.raises(LookupError) as excinfo:
+    # When / Then
+    with pytest.raises(lookup.DetermineURIError):
         lookup.determine_uri(environment=environment, discovery_address=discovery)
-
-    # Then
-    assert "Cannot determine discovery URI" in str(excinfo.value)

--- a/tests/_internal/test_config.py
+++ b/tests/_internal/test_config.py
@@ -4,16 +4,21 @@ from h2o_discovery._internal import config
 
 
 def config_test_cases():
-    yield pytest.param("", config.Config(tokens={}), id="empty config")
+    yield pytest.param("", config.Config(endpoint=None, tokens={}), id="empty config")
     yield pytest.param(
         """
+        Endpoint = "https://cloud.h2o.ai"
         ClientID = "client-id"
         Token = "TestToken"
         PlatformClientID = "platform-client-id"
         PlatformToken = "TestPlatformToken"
         """,
         config.Config(
-            tokens={"client-id": "TestToken", "platform-client-id": "TestPlatformToken"}
+            endpoint="https://cloud.h2o.ai",
+            tokens={
+                "client-id": "TestToken",
+                "platform-client-id": "TestPlatformToken",
+            },
         ),
         id="full config",
     )
@@ -32,6 +37,13 @@ def config_test_cases():
         """,
         config.Config(tokens={"platform-client-id": "TestPlatformToken"}),
         id="platform token only",
+    )
+    yield pytest.param(
+        """
+        Endpoint = "https://cloud.h2o.ai"
+        """,
+        config.Config(endpoint="https://cloud.h2o.ai", tokens={}),
+        id="endpoint only",
     )
 
 


### PR DESCRIPTION
`determine_uri` now accepts `config_endpoint` as the existence of `H2OCONFIG` is not in the concernt of it, we moved the verbose `LookupError` to the main functrions.

RESOLVES https://github.com/h2oai/cloud-discovery/issues/438
