### PR TITLE
feat: 🥅 handle errors that hint discovery server not being enabled in environment.

### DIFF
--- a/src/h2o_discovery/__init__.py
+++ b/src/h2o_discovery/__init__.py
@@ -4,6 +4,7 @@ from typing import Optional
 from typing import Tuple
 from typing import Union
 
+from h2o_discovery import exceptions
 from h2o_discovery import model
 from h2o_discovery._internal import client
 from h2o_discovery._internal import config
@@ -40,7 +41,9 @@ def discover(
         config_path: The path to the H2O CLI configuration file.
 
     Raises:
-        LookupError: If the URI cannot be determined.
+        exceptions.DiscoveryLookupError: If the URI cannot be determined.
+        exceptions.H2OCloudEnvironmentError: If there seems to be a problem with the
+            deployment of the server side.
     """
     uri, cfg = _lookup_and_load(environment, discovery_address, config_path)
 
@@ -78,7 +81,9 @@ async def discover_async(
         config_path: The path to the H2O CLI configuration file.
 
     Raises:
-        LookupError: If the URI cannot be determined.
+        exceptions.DiscoveryLookupError: If the URI cannot be determined.
+        exceptions.H2OCloudEnvironmentError: If there seems to be a problem with the
+            deployment of the server side.
     """
 
     uri, cfg = _lookup_and_load(environment, discovery_address, config_path)
@@ -101,7 +106,7 @@ def _lookup_and_load(
     try:
         uri = lookup.determine_uri(environment, discovery_address, cfg.endpoint)
     except lookup.DetermineURIError:
-        raise LookupError(
+        raise exceptions.DiscoveryLookupError(
             "Cannot determine discovery URI."
             " Please set H2O_CLOUD_ENVIRONMENT or H2O_CLOUD_DISCOVERY environment"
             " variables or use the environment or discovery parameters."

--- a/src/h2o_discovery/_internal/load.py
+++ b/src/h2o_discovery/_internal/load.py
@@ -1,27 +1,39 @@
+import json
 import os
 import types
 from typing import Iterable
 from typing import Mapping
 from typing import Optional
 
+import httpx
+
+from h2o_discovery import exceptions
 from h2o_discovery import model
 from h2o_discovery._internal import client
 
 
 def load_discovery(cl: client.Client) -> model.Discovery:
     """Loads the discovery records from the Discovery Service."""
-    environment = cl.get_environment()
-    services = _get_service_map(cl.list_services())
-    clients = _get_client_map(cl.list_clients())
+    try:
+        environment = cl.get_environment()
+        services = _get_service_map(cl.list_services())
+        clients = _get_client_map(cl.list_clients())
+    except Exception as e:
+        _handle_specific_client_exceptions(e)
+        raise
 
     return model.Discovery(environment=environment, services=services, clients=clients)
 
 
 async def load_discovery_async(cl: client.AsyncClient) -> model.Discovery:
     """Loads the discovery records from the Discovery Service."""
-    environment = await cl.get_environment()
-    services = _get_service_map(await cl.list_services())
-    clients = _get_client_map(await cl.list_clients())
+    try:
+        environment = await cl.get_environment()
+        services = _get_service_map(await cl.list_services())
+        clients = _get_client_map(await cl.list_clients())
+    except Exception as e:
+        _handle_specific_client_exceptions(e)
+        raise
 
     return model.Discovery(environment=environment, services=services, clients=clients)
 
@@ -75,3 +87,17 @@ def _client_key(name: str) -> str:
     if name.startswith(_CLIENTS_COLLECTION_PREFIX):
         return name[len(_CLIENTS_COLLECTION_PREFIX) :]
     raise ValueError(f"invalid client name: {name}")
+
+
+_ENV_ERROR = exceptions.H2OCloudEnvironmentError(
+    "Received an unexpected response from the server."
+    " Please make sure that the environment you are trying to connect to is"
+    " configured correctly and has the H2O Cloud Discovery Service enabled."
+)
+
+
+def _handle_specific_client_exceptions(e: Exception) -> None:
+    if isinstance(e, json.decoder.JSONDecodeError):
+        raise _ENV_ERROR from e
+    if isinstance(e, httpx.HTTPStatusError) and e.response.status_code == 404:
+        raise _ENV_ERROR from e

--- a/src/h2o_discovery/exceptions.py
+++ b/src/h2o_discovery/exceptions.py
@@ -1,0 +1,12 @@
+class DiscoveryError(Exception):
+    """Base class for all exceptions of the H2O Cloud discovery Client."""
+
+
+class DiscoveryLookupError(DiscoveryError, LookupError):
+    """Raised when the discovery URI cannot be determined."""
+
+
+class H2OCloudEnvironmentError(DiscoveryError):
+    """Raised when there seems to be a problem with the deployment of the server
+    side.
+    """


### PR DESCRIPTION
As this is second specific exception raised from the main functions, we adopt custom exceptions pattern.

`load` functions now check some specific errors that can hint that the environment does not have discovery service installed.

RESOLVES #23 
