### PR TITLE
chore: 💚 update `pydoc-markdown`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ fix = [
 
 [tool.hatch.envs.docs]
 dependencies = [
-  "pydoc-markdown==4.6.4",
+  "pydoc-markdown~=4.8",
 ]
 
 [tool.hatch.envs.docs.scripts]


### PR DESCRIPTION
This fixes error on the CI (https://github.com/h2oai/cloud-discovery-py/actions/runs/6219626115/job/16878063334)

API doc was for the release was updated manually.