### PR TITLE
chore: 🔨 use `ruff format` instead of `black` for formatting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,20 +66,19 @@ template = "test"
 
 [tool.hatch.envs.lint]
 dependencies = [
-  "black==22.10.0",
   "mypy~=1.1",
-  "ruff==0.0.286",
+  "ruff==0.1.11",
 ]
 
 [tool.hatch.envs.lint.scripts]
 check = [
-  "black --check .",
+  "ruff format --check .",
   "ruff check .",
   "mypy src",
 ]
 fix = [
   "ruff check --fix .",
-  "black .",
+  "ruff format .",
   "check",
 ]
 
@@ -91,14 +90,15 @@ dependencies = [
 [tool.hatch.envs.docs.scripts]
 generate = "pydoc-markdown"
 
-[tool.black]
-skip-magic-trailing-comma = true
-
 [tool.ruff]
 extend-select = ["I", "B", "A", "ERA"]
 line-length = 88 # Same as black.
 src = ["src", "test"]
 target-version = "py37"
+
+[tool.ruff.format]
+docstring-code-format = true
+skip-magic-trailing-comma = true
 
 [tool.ruff.isort]
 case-sensitive = false

--- a/src/h2o_discovery/_internal/lookup.py
+++ b/src/h2o_discovery/_internal/lookup.py
@@ -47,7 +47,7 @@ def _discovery_uri_from_environment(environment: str):
 
 
 def determine_local_config_path(
-    config_path: Optional[Optional[Union[str, bytes, os.PathLike]]] = None
+    config_path: Optional[Optional[Union[str, bytes, os.PathLike]]] = None,
 ) -> Optional[str]:
     """Uses passed parameter, environment variable and H2O CLI default to get the
     path to the local config file.


### PR DESCRIPTION
[`ruff format` is available from `0.1.2`](https://docs.astral.sh/ruff/formatter/) using instead of `black`:
 - removes one dependency/tool
 - improves speed of the linting.

one trailing comma added by the formatter.