### PR TITLE
ci: 💚 fix release please work flow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
 
     steps:
       - uses: google-github-actions/release-please-action@v4
@@ -24,7 +25,7 @@ jobs:
     name: Release to PyPI
     uses: ./.github/workflows/pypi-release.yml
 
-    if: needs.release-please.outputs.releases_created
+    if: needs.release-please.outputs.releases_created == 'true'
     needs: release-please
 
     secrets: inherit
@@ -33,7 +34,7 @@ jobs:
     name: Attach API Docs to Release
     uses: ./.github/workflows/api-docs-release.yml
 
-    if: needs.release-please.outputs.releases_created
+    if: needs.release-please.outputs.releases_created == 'true'
     needs: release-please
 
     with:


### PR DESCRIPTION
Currently the release workflow executes with any commit to default branch. It fails as the upload to the PyPI fails on uniqueness constraint.

 - fix condition so that it's evaluated as bool.
 - set job output tag.
