### PR TITLE
ci: 💚 remove dependency on the ops account for release please jobs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,11 +15,13 @@ jobs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
 
+    permissions:
+      contents: write
+      pull-requests: write
+
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
-        with:
-          token: ${{ secrets.RELEASE_PLEASE_GITHUB_TOKEN }}
 
   release-pypi:
     name: Release to PyPI
@@ -36,6 +38,9 @@ jobs:
 
     if: needs.release-please.outputs.releases_created == 'true'
     needs: release-please
+
+    permissions:
+      contents: write
 
     with:
       tag: ${{ needs.release-please.outputs.tag_name }}


### PR DESCRIPTION
It stopped working on https://github.com/h2oai/authn-py and with draft releases finaly working in the action it's not so much.
