### PR TITLE
ci: 👷 drop use of the token for PyPI release

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -32,8 +32,6 @@ jobs:
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
-          verify_metadata: false
+          verify-metadata: false
           verbose: true
-          print_hash: true
+          print-hash: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,7 +30,8 @@ jobs:
     if: needs.release-please.outputs.releases_created == 'true'
     needs: release-please
 
-    secrets: inherit
+    permissions:
+      id-token: write
 
   release-api-docs:
     name: Attach API Docs to Release
@@ -44,5 +45,3 @@ jobs:
 
     with:
       tag: ${{ needs.release-please.outputs.tag_name }}
-
-    secrets: inherit


### PR DESCRIPTION
This repo should be authorized as the trusted publisher.

Also adjusted config keys to preferred `kebab-case`.

TOKEN itself will be removed once we confirm that this works.
