### PR TITLE
ci: 💚 disable pypi attestations production and upload

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -5,6 +5,11 @@ on:
   pull_request:
   workflow_call:
 
+# TODO(@zoido): Remove permissions when latest version is uploaded.
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   test:
     name: Test

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,14 +1,7 @@
 name: Release Python package to PyPI
 
 on:
-  # TODO(@zoido): Remove pull_request when latest version is uploaded.
-  pull_request:
   workflow_call:
-
-# TODO(@zoido): Remove permissions when latest version is uploaded.
-permissions:
-  contents: read
-  id-token: write
 
 jobs:
   test:

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,6 +1,8 @@
 name: Release Python package to PyPI
 
 on:
+  # TODO(@zoido): Remove pull_request when latest version is uploaded.
+  pull_request:
   workflow_call:
 
 jobs:
@@ -35,3 +37,9 @@ jobs:
           verify-metadata: false
           verbose: true
           print-hash: true
+
+          # Attentions are disabled temporarily. They do seem to work with the
+          # reusable wokrflow.
+          # - https://github.com/pypa/gh-action-pypi-publish/issues/166
+          # - https://github.com/pypa/gh-action-pypi-publish/issues/283
+          attestations: false


### PR DESCRIPTION
They do no seem to work with reusable workflows (see the issues in the comment)
