### PR TITLE
chore: Bump pytest and pytest-asyncio version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,8 @@ matrix.httpx.dependencies = [
 
 [tool.hatch.envs.test]
 dependencies = [
-  "pytest-asyncio==0.20.2",
-  "pytest==7.2",
+  "pytest-asyncio==0.24.0",
+  "pytest==8.3",
   "respx>=0.16",
 ]
 dev-mode = false
@@ -92,6 +92,9 @@ dependencies = [
 
 [tool.hatch.envs.docs.scripts]
 generate = "pydoc-markdown"
+
+[tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 
 [tool.ruff]
 extend-select = ["I", "B", "A", "ERA"]


### PR DESCRIPTION
This is to avoid deprecation warnings with higher python versions.
`pytest-asyncio==0.24.0` is the latest version that supports Python 3.8.
