### PR TITLE
test: ✅ Extend testing in Python 3.13+ 

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13",]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4
@@ -19,6 +19,7 @@ jobs:
         id: setup-python
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13",]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-python@v5
         id: setup-python
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4
@@ -19,6 +19,7 @@ jobs:
         id: setup-python
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4
@@ -20,6 +20,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
+
 
       - uses: actions/cache@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,8 @@ matrix.httpx.dependencies = [
 
 [tool.hatch.envs.test]
 dependencies = [
-  "pytest-asyncio==0.24.0",
+  "pytest-asyncio==0.24.0 ; python_version < '3.9'",
+  "pytest-asyncio==0.25.1 ;python_version >= '3.9'",
   "pytest==8.3",
   "respx>=0.16",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ classifiers = [
   "Topic :: Utilities",
 ]
 dependencies = [
-  "httpx>=0.16",
+  "httpx>=0.16 ; python_version < '3.13'" ,
+  "httpx>=0.23 ; python_version >= '3.13'" ,
   "tomli >= 1.1.0 ; python_version < '3.11'",
 ]
 description = 'H2O Cloud Discovery Python CLient'
@@ -38,7 +39,11 @@ include = ["/src", "/tests", "CHANGELOG.md"]
 packages = ["src/h2o_discovery"]
 
 [[tool.hatch.envs.test.matrix]]
-httpx = ["httpx0.16", "httpx0.21", "httpx0.22", "httpx0.23", "httpx0.24", "httpx0.25", "httpx0.26"]
+httpx = ["httpx0.23", "httpx0.24", "httpx0.25", "httpx0.26", "httpx0.27", "httpx0.28"]
+python = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+
+[[tool.hatch.envs.test.matrix]]
+httpx = ["httpx0.16", "httpx0.21", "httpx0.22"]
 python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
 [tool.hatch.envs.test.overrides]
@@ -50,6 +55,8 @@ matrix.httpx.dependencies = [
   {value = "httpx==0.24.*", if = ["httpx0.24"]},
   {value = "httpx==0.25.*", if = ["httpx0.25"]},
   {value = "httpx==0.26.*", if = ["httpx0.26"]},
+  {value = "httpx==0.27.*", if = ["httpx0.27"]},
+  {value = "httpx==0.28.*", if = ["httpx0.28"]},
 ]
 
 [tool.hatch.envs.test]

--- a/tests/_internal/load/test_load_discovery.py
+++ b/tests/_internal/load/test_load_discovery.py
@@ -7,8 +7,7 @@ from h2o_discovery import model
 from h2o_discovery._internal import load
 
 
-@pytest.fixture()
-def mock_client():
+def mock_async_client():
     client = mock.Mock()
     client.get_environment.return_value = asyncio.Future()
     client.get_environment.return_value.set_result(mock.Mock())
@@ -16,6 +15,16 @@ def mock_client():
     client.list_services.return_value.set_result({})
     client.list_clients.return_value = asyncio.Future()
     client.list_clients.return_value.set_result({})
+
+    return client
+
+
+def mock_sync_client():
+    client = mock.Mock()
+    client.get_environment.return_value = {}
+    client.list_services.return_value = {}
+    client.list_clients.return_value = {}
+    client.list_clients.return_value = {}
 
     return client
 
@@ -28,8 +37,9 @@ ENVIRONMENT_DATA = model.Environment(
 )
 
 
-def test_load_environment(mock_client):
+def test_load_environment():
     # Given
+    mock_client = mock_sync_client()
     mock_client.get_environment.return_value = ENVIRONMENT_DATA
 
     # When
@@ -40,8 +50,9 @@ def test_load_environment(mock_client):
 
 
 @pytest.mark.asyncio
-async def test_load_environment_async(mock_client):
+async def test_load_environment_async():
     # Given
+    mock_client = mock_async_client()
     mock_client.get_environment.return_value = asyncio.Future()
     mock_client.get_environment.return_value.set_result(ENVIRONMENT_DATA)
 
@@ -52,8 +63,9 @@ async def test_load_environment_async(mock_client):
     assert discovery.environment == ENVIRONMENT_DATA
 
 
-def test_load_services(mock_client):
+def test_load_services():
     # Given
+    mock_client = mock_sync_client()
     mock_client.list_services.return_value = [SERVICE_RECORD]
 
     # When
@@ -74,8 +86,9 @@ SERVICE_RECORD = model.Service(
 
 
 @pytest.mark.asyncio
-async def test_load_services_async(mock_client):
+async def test_load_services_async():
     # Given
+    mock_client = mock_async_client()
     mock_client.list_services.return_value = asyncio.Future()
     mock_client.list_services.return_value.set_result([SERVICE_RECORD])
 
@@ -93,8 +106,9 @@ CLIENT_RECORD = model.Client(
 )
 
 
-def test_load_clients(mock_client):
+def test_load_clients():
     # Given
+    mock_client = mock_sync_client()
     mock_client.list_clients.return_value = [CLIENT_RECORD]
 
     # When
@@ -105,8 +119,9 @@ def test_load_clients(mock_client):
 
 
 @pytest.mark.asyncio
-async def test_load_clients_async(mock_client):
+async def test_load_clients_async():
     # Given
+    mock_client = mock_async_client()
     mock_client.list_clients.return_value = asyncio.Future()
     mock_client.list_clients.return_value.set_result([CLIENT_RECORD])
 


### PR DESCRIPTION
[Python 3.13 removed cgi module](https://docs.python.org/3.13/library/cgi.html), which is used by httpx 0.22 and lower.
So we do not test with lower version with Python 3.13 and set higher requirements for Python 3.13+

Tests were producing deprecation warning on the places when we assign futures to mock so I rewrote initialization of the mocks.

`pytest-asyncio` produces deprecation warnings with Python 3.14, so I added python version constraints to the test dependencies and use the newest `pytest-asyncio` for python 3.9+

Newer versions of httpx are added to testing matrix.