### PR TITLE
refactor: 🚧 Add support for link entity to client

### DIFF
--- a/src/h2o_discovery/_internal/client.py
+++ b/src/h2o_discovery/_internal/client.py
@@ -12,6 +12,7 @@ from h2o_discovery import model
 _ENVIRONMENT_ENDPOINT = "v1/environment"
 _SERVICES_ENDPOINT = "v1/services"
 _CLIENTS_ENDPOINT = "v1/clients"
+_LINKS_ENDPOINT = "v1/links"
 
 DEFAULT_HTTP_TIMEOUT = datetime.timedelta(seconds=5)
 
@@ -56,6 +57,12 @@ class Client(_BaseClient):
         """Returns the list of all registered clients."""
         return self._get_all_entities(
             _CLIENTS_ENDPOINT, "clients", model.Client.from_json_dict
+        )
+
+    def list_links(self) -> List[model.Link]:
+        """Returns the list of all registered links."""
+        return self._get_all_entities(
+            _LINKS_ENDPOINT, "links", model.Link.from_json_dict
         )
 
     def _get_all_entities(
@@ -121,6 +128,12 @@ class AsyncClient(_BaseClient):
         """Returns the list of all registered clients."""
         return await self._get_all_entities(
             _CLIENTS_ENDPOINT, "clients", model.Client.from_json_dict
+        )
+
+    async def list_links(self) -> List[model.Link]:
+        """Returns the list of all registered links."""
+        return await self._get_all_entities(
+            _LINKS_ENDPOINT, "links", model.Link.from_json_dict
         )
 
     async def _get_all_entities(

--- a/src/h2o_discovery/model.py
+++ b/src/h2o_discovery/model.py
@@ -111,6 +111,28 @@ class Environment:
 
 
 @dataclasses.dataclass(frozen=True)
+class Link:
+    """Representation of the navigation link."""
+
+    #: Canonical name of the Link. For example: "links/app-link".
+    name: str
+
+    #: Value that applications can put into the HTML anchor's href
+    #: attribute to navigate to link.
+    uri: str
+
+    #: Preferred text to use as a link text. This usually make sense
+    #: only as part of the navigation menus.
+    #:     Example: <a href="{{ link.uri }}">{{ link.text }}</a>
+    text: Optional[str]
+
+    @classmethod
+    def from_json_dict(cls, json: Mapping[str, str]) -> "Link":
+        """Create a Link from a JSON dict returned by the server."""
+        return cls(name=json["name"], uri=json["uri"], text=json.get("text"))
+
+
+@dataclasses.dataclass(frozen=True)
 class Credentials:
     """Contain credentials associated with single registered client.
 

--- a/tests/_internal/test_client.py
+++ b/tests/_internal/test_client.py
@@ -335,10 +335,10 @@ def test_client_list_links_can_handle_empty_response():
     cl = client.Client("https://test.example.com")
 
     # When
-    services = cl.list_links()
+    links = cl.list_links()
 
     # Then
-    assert services == []
+    assert links == []
 
 
 @respx.mock
@@ -349,10 +349,10 @@ async def test_async_client_list_links_can_handle_empty_response():
     cl = client.AsyncClient("https://test.example.com")
 
     # When
-    services = await cl.list_links()
+    links = await cl.list_links()
 
     # Then
-    assert services == []
+    assert links == []
 
 
 def _assert_pagination_api_calls(route):

--- a/tests/_internal/test_client.py
+++ b/tests/_internal/test_client.py
@@ -220,7 +220,6 @@ def test_client_list_links_internal():
     links = cl.list_links()
 
     # Then
-
     assert links == EXPECTED_LINKS_RECORDS
     _assert_pagination_api_calls(route)
 
@@ -237,7 +236,6 @@ def test_client_list_links_public():
     links = cl.list_links()
 
     # Then
-
     assert links == EXPECTED_LINKS_RECORDS
     _assert_pagination_api_calls(route)
 
@@ -255,7 +253,6 @@ async def test_async_client_list_links_internal():
     links = await cl.list_links()
 
     # Then
-
     assert links == EXPECTED_LINKS_RECORDS
     _assert_pagination_api_calls(route)
 
@@ -273,7 +270,6 @@ async def test_async_client_list_links_public():
     links = await cl.list_links()
 
     # Then
-
     assert links == EXPECTED_LINKS_RECORDS
     _assert_pagination_api_calls(route)
 

--- a/tests/_internal/test_client.py
+++ b/tests/_internal/test_client.py
@@ -123,7 +123,7 @@ async def test_async_client_list_services_internal():
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_async_client_list_services_pubclic():
+async def test_async_client_list_services_public():
     # Given
     route = respx.get("https://test.example.com/.ai.h2o.cloud.discovery/v1/services")
     route.side_effect = SERVICES_RESPONSES
@@ -209,6 +209,76 @@ async def test_async_client_list_clients_public():
 
 
 @respx.mock
+def test_client_list_links_internal():
+    # Given
+    route = respx.get("http://test.example.com:1234/v1/links")
+    route.side_effect = LINKS_RESPONSES
+
+    cl = client.Client("http://test.example.com:1234")
+
+    # When
+    links = cl.list_links()
+
+    # Then
+
+    assert links == EXPECTED_LINKS_RECORDS
+    _assert_pagination_api_calls(route)
+
+
+@respx.mock
+def test_client_list_links_public():
+    # Given
+    route = respx.get("https://test.example.com/.ai.h2o.cloud.discovery/v1/links")
+    route.side_effect = LINKS_RESPONSES
+
+    cl = client.Client("https://test.example.com/.ai.h2o.cloud.discovery")
+
+    # When
+    links = cl.list_links()
+
+    # Then
+
+    assert links == EXPECTED_LINKS_RECORDS
+    _assert_pagination_api_calls(route)
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_async_client_list_links_internal():
+    # Given
+    route = respx.get("https://test.example.com:1234/v1/links")
+    route.side_effect = LINKS_RESPONSES
+
+    cl = client.AsyncClient("https://test.example.com:1234")
+
+    # When
+    links = await cl.list_links()
+
+    # Then
+
+    assert links == EXPECTED_LINKS_RECORDS
+    _assert_pagination_api_calls(route)
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_async_client_list_links_public():
+    # Given
+    route = respx.get("https://test.example.com/.ai.h2o.cloud.discovery/v1/links")
+    route.side_effect = LINKS_RESPONSES
+
+    cl = client.AsyncClient("https://test.example.com/.ai.h2o.cloud.discovery")
+
+    # When
+    links = await cl.list_links()
+
+    # Then
+
+    assert links == EXPECTED_LINKS_RECORDS
+    _assert_pagination_api_calls(route)
+
+
+@respx.mock
 def test_client_list_services_can_handle_empty_response():
     # Given
     respx.get("https://test.example.com/v1/services").respond(json={})
@@ -257,6 +327,33 @@ async def test_async_client_list_clients_can_handle_empty_response():
 
     # When
     services = await cl.list_clients()
+
+    # Then
+    assert services == []
+
+
+@respx.mock
+def test_client_list_links_can_handle_empty_response():
+    # Given
+    respx.get("https://test.example.com/v1/links").respond(json={})
+    cl = client.Client("https://test.example.com")
+
+    # When
+    services = cl.list_links()
+
+    # Then
+    assert services == []
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_async_client_list_links_can_handle_empty_response():
+    # Given
+    respx.get("https://test.example.com/v1/links").respond(json={})
+    cl = client.AsyncClient("https://test.example.com")
+
+    # When
+    services = await cl.list_links()
 
     # Then
     assert services == []
@@ -435,5 +532,63 @@ EXPECTED_CLIENTS_RECORDS = [
         name="clients/test-client-4",
         display_name="Test Client 4",
         oauth2_client_id="test-client-4",
+    ),
+]
+
+
+LINKS_RESPONSES = [
+    httpx.Response(
+        200,
+        json={
+            "links": [
+                {"name": "links/test-link-1", "uri": "http://test-link-1.domain:1234"},
+                {
+                    "name": "links/test-link-2",
+                    "uri": "http://test-link-2.domain:1234",
+                    "text": "Test Link 2",
+                },
+            ],
+            "nextPageToken": "next-page-token-1",
+        },
+    ),
+    httpx.Response(
+        200,
+        json={
+            "links": [
+                {
+                    "name": "links/test-link-3",
+                    "uri": "http://test-link-3.domain:1234",
+                    "text": "Test Link 3",
+                }
+            ],
+            "nextPageToken": "next-page-token-2",
+        },
+    ),
+    httpx.Response(
+        200,
+        json={
+            "links": [
+                {"name": "links/test-link-4", "uri": "http://test-link-4.domain:1234"}
+            ]
+        },
+    ),
+]
+
+EXPECTED_LINKS_RECORDS = [
+    model.Link(
+        name="links/test-link-1", uri="http://test-link-1.domain:1234", text=None
+    ),
+    model.Link(
+        name="links/test-link-2",
+        uri="http://test-link-2.domain:1234",
+        text="Test Link 2",
+    ),
+    model.Link(
+        name="links/test-link-3",
+        uri="http://test-link-3.domain:1234",
+        text="Test Link 3",
+    ),
+    model.Link(
+        name="links/test-link-4", uri="http://test-link-4.domain:1234", text=None
     ),
 ]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -84,3 +84,33 @@ def test_environment_from_json_dict_with_missing_version():
         h2o_cloud_platform_oauth2_scope="test-platform-scope",
         h2o_cloud_version=None,
     )
+
+
+def test_link_from_json_dictt():
+    # Given
+    json = {
+        "name": "links/test-link",
+        "uri": "http://test-link.domain:1234",
+        "text": "Test Link",
+    }
+
+    # When
+    result = model.Link.from_json_dict(json)
+
+    # Then
+    assert result == model.Link(
+        name="links/test-link", uri="http://test-link.domain:1234", text="Test Link"
+    )
+
+
+def test_link_from_json_dict_with_missing_text():
+    # Given
+    json = {"name": "links/test-link", "uri": "http://test-link.domain:1234"}
+
+    # When
+    result = model.Link.from_json_dict(json)
+
+    # Then
+    assert result == model.Link(
+        name="links/test-link", uri="http://test-link.domain:1234", text=None
+    )


### PR DESCRIPTION
- defines the model for the link entity
- add methods for fetching links from the server

PART OF https://github.com/h2oai/cloud-discovery/issues/694
