### PR TITLE
feat: ✨ Discover registered links when available

### DIFF
--- a/src/h2o_discovery/model.py
+++ b/src/h2o_discovery/model.py
@@ -167,6 +167,9 @@ class Discovery:
     #: Map of registered clients in the `{"client-identifier": Client(...)}` format.
     clients: Mapping[str, Client]
 
+    #: Map of registered links in the `{"link-identifier": Link(...)}` format.
+    links: Mapping[str, Link]
+
     #: Map of credentials in the `{"client-identifier": Credentials(...)}` format.
     credentials: Mapping[str, Credentials] = dataclasses.field(
         default_factory=_empty_credentials_factory


### PR DESCRIPTION
- add links map to the discovery model
- load links when the discover is called

As Links are new addtion to the API, we do not fail when server returns 404 and only have no links available. All this to have backward compatibility.

RESOLVES https://github.com/h2oai/cloud-discovery/issues/694
