### PR TITLE
fix: 🐛 Make addition of links to the discovery model backward compatible

### DIFF
--- a/src/h2o_discovery/model.py
+++ b/src/h2o_discovery/model.py
@@ -23,19 +23,19 @@ class Service:
     #: Can be the version of the API or the version of
     #: the service. Clients can utilize this information change their behavior
     #: in accessing the service or downloading the correct client version.
-    version: Optional[str]
+    version: Optional[str] = None
 
     #: OAuth 2.0 Scope required to access the service.
     #: Clients request the access token with this scope in order to access the service.
     #: If the scope is not defined (or empty), clients should use
     #: h2o_cloud_platform_scope.
-    oauth2_scope: Optional[str]
+    oauth2_scope: Optional[str] = None
 
     #: Requirement Specifier (PEP 508) for the Python client that can be used for
     #: accessing the service.
     #: Any string that can be `pip install`ed.
     #:     Example: my-client==0.1.0
-    python_client: Optional[str]
+    python_client: Optional[str] = None
 
     @classmethod
     def from_json_dict(cls, json: Mapping[str, str]) -> "Service":
@@ -97,7 +97,7 @@ class Environment:
     #: In the XC YY.MM.V format for released versions (e.g. MC 23.04.01 for managed
     #: cloud or HC 23.01.1 for hybrid cloud). Can be arbitrary string for
     #: testing or special environments.
-    h2o_cloud_version: Optional[str]
+    h2o_cloud_version: Optional[str] = None
 
     @classmethod
     def from_json_dict(cls, json: Mapping[str, str]) -> "Environment":
@@ -154,6 +154,10 @@ def _empty_credentials_factory() -> Mapping[str, Credentials]:
     return types.MappingProxyType({})
 
 
+def _empty_links_factory() -> Mapping[str, Link]:
+    return types.MappingProxyType({})
+
+
 @dataclasses.dataclass(frozen=True)
 class Discovery:
     """Representation of the discovery records."""
@@ -168,7 +172,7 @@ class Discovery:
     clients: Mapping[str, Client]
 
     #: Map of registered links in the `{"link-identifier": Link(...)}` format.
-    links: Mapping[str, Link]
+    links: Mapping[str, Link] = dataclasses.field(default_factory=_empty_links_factory)
 
     #: Map of credentials in the `{"client-identifier": Credentials(...)}` format.
     credentials: Mapping[str, Credentials] = dataclasses.field(

--- a/tests/_internal/test_client.py
+++ b/tests/_internal/test_client.py
@@ -440,25 +440,16 @@ EXPECTED_SERVICES_RECORDS = [
         name="services/test-service-2",
         display_name="Test Service 2",
         uri="http://test-service-2.domain:1234",
-        version=None,
-        oauth2_scope=None,
-        python_client=None,
     ),
     model.Service(
         name="services/test-service-3",
         display_name="Test Service 3",
         uri="http://test-service-3.domain:1234",
-        version=None,
-        oauth2_scope=None,
-        python_client=None,
     ),
     model.Service(
         name="services/test-service-4",
         display_name="Test Service 4",
         uri="http://test-service-4.domain:1234",
-        version=None,
-        oauth2_scope=None,
-        python_client=None,
     ),
 ]
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -113,3 +113,25 @@ def test_link_from_json_dict_with_missing_text():
     assert result == model.Link(
         name="links/test-link", uri="http://test-link.domain:1234", text=None
     )
+
+
+def test_discovery_without_links_ok():
+    """Test that Discovery can be created without explicitly providing links in
+    the constructor to ensure backward compatibility.
+    """
+
+    # When
+    _ = model.Discovery(
+        environment=model.Environment(
+            h2o_cloud_environment="https://test.h2o.ai",
+            issuer_url="https://test.h2o.ai",
+            h2o_cloud_platform_oauth2_scope="test-platform-scope",
+        ),
+        credentials={},
+        services={},
+        clients={},
+        # No links,
+    )
+
+    # Then
+    # No exception is raised.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -82,7 +82,6 @@ def test_environment_from_json_dict_with_missing_version():
         h2o_cloud_environment="https://test.h2o.ai",
         issuer_url="https://test.h2o.ai",
         h2o_cloud_platform_oauth2_scope="test-platform-scope",
-        h2o_cloud_version=None,
     )
 
 


### PR DESCRIPTION
`h2o_discovert.model` uses `dataclasses` module and let it generate `__init__` method.
We do not set any default value for any `Optional` field, so the generated `__init__` method
looks like this:

```py
def __init__(self, field1: Optional[str], field2: Optional[str], field3: Optional[str]):
```

That makes all fileds required args in the constructor.

Adding links therefore added new required `links` argument to the
`h2o_discovert.model.Discovery` constructor.

We set the default value for `links` field of the `Discovery` class
and to all Optional fields of other classes as well to establish the pattern.
