### PR TITLE
feat: improve compatibility with Python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
 ]
 dependencies = [
   "httpx>=0.23",
+  "httpx>=0.25.1; python_version >= '3.14'",
   "tomli >= 1.1.0 ; python_version < '3.11'",
 ]
 description = 'H2O Cloud Discovery Python CLient'
@@ -39,7 +40,11 @@ packages = ["src/h2o_discovery"]
 
 [[tool.hatch.envs.test.matrix]]
 httpx = ["httpx0.23", "httpx0.24", "httpx0.25", "httpx0.26", "httpx0.27", "httpx0.28"]
-python = ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
+
+[[tool.hatch.envs.test.matrix]]
+httpx = ["httpx0.25", "httpx0.26", "httpx0.27", "httpx0.28"]
+python = ["3.14"]
 
 [tool.hatch.envs.test.overrides]
 matrix.httpx.dependencies = [


### PR DESCRIPTION
`httpcore` that is dependency of the `httpx` causes `AttributeError` for `httpcore<1.0.8`.
(https://github.com/encode/httpcore/blob/master/CHANGELOG.md#version-108-april-11th-2025)

Support for `httpcore>=1.0` was added in `httpc==0.25.1`.
(https://github.com/encode/httpx/blob/master/CHANGELOG.md#0251-3rd-november-2023)

Constraining  httpx for python 3.14  allows to use resolve httpx to versions can use `httpcore` that fixes the issue for python 3.14
