### PR TITLE
fix: 🐛 don't load credentials when config does not match the discovered environment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
 ]
 dependencies = [
   "httpx>=0.23",
+  "httpx>=0.25.1; python_version >= '3.14'",
   "tomli >= 1.1.0 ; python_version < '3.11'",
 ]
 description = 'H2O Cloud Discovery Python CLient'
@@ -39,7 +40,11 @@ packages = ["src/h2o_discovery"]
 
 [[tool.hatch.envs.test.matrix]]
 httpx = ["httpx0.23", "httpx0.24", "httpx0.25", "httpx0.26", "httpx0.27", "httpx0.28"]
-python = ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
+
+[[tool.hatch.envs.test.matrix]]
+httpx = ["httpx0.25", "httpx0.26", "httpx0.27", "httpx0.28"]
+python = ["3.14"]
 
 [tool.hatch.envs.test.overrides]
 matrix.httpx.dependencies = [

--- a/src/h2o_discovery/__init__.py
+++ b/src/h2o_discovery/__init__.py
@@ -60,10 +60,7 @@ def discover(
     discovery = load.load_discovery(
         client.Client(uri=uri, timeout=http_timeout, ssl_context=ssl_context)
     )
-    credentials = load.load_credentials(
-        clients=discovery.clients, config_tokens=cfg.tokens
-    )
-
+    credentials = load.load_credentials(discovery=discovery, cfg=cfg)
     return dataclasses.replace(discovery, credentials=credentials)
 
 
@@ -110,10 +107,7 @@ async def discover_async(
     discovery = await load.load_discovery_async(
         client.AsyncClient(uri=uri, timeout=http_timeout, ssl_context=ssl_context)
     )
-    credentials = load.load_credentials(
-        clients=discovery.clients, config_tokens=cfg.tokens
-    )
-
+    credentials = load.load_credentials(discovery=discovery, cfg=cfg)
     return dataclasses.replace(discovery, credentials=credentials)
 
 

--- a/tests/_internal/load/test_load_credentials.py
+++ b/tests/_internal/load/test_load_credentials.py
@@ -1,5 +1,12 @@
 from h2o_discovery import model
+from h2o_discovery._internal import config
 from h2o_discovery._internal import load
+
+_ENVIRONMENT = model.Environment(
+    h2o_cloud_environment="https://example.com",
+    issuer_url="https://example.com",
+    h2o_cloud_platform_oauth2_scope=["scope1", "scope2"],
+)
 
 
 def test_load_credentials(monkeypatch):
@@ -24,8 +31,11 @@ def test_load_credentials(monkeypatch):
     tokens = {"config-client-id": "config-token"}
     monkeypatch.setenv("H2O_CLOUD_CLIENT_ENV_CLIENT_TOKEN", "env-token")
 
+    discovery = model.Discovery(clients=clients, environment=_ENVIRONMENT, services={})
+    cfg = config.Config(tokens=tokens, endpoint=_ENVIRONMENT.h2o_cloud_environment)
+
     # When
-    result = load.load_credentials(clients=clients, config_tokens=tokens)
+    result = load.load_credentials(discovery=discovery, cfg=cfg)
 
     # Then
     assert result == {
@@ -33,4 +43,33 @@ def test_load_credentials(monkeypatch):
         "config_client": model.Credentials(
             client="config_client", refresh_token="config-token"
         ),
+    }
+
+
+def test_load_credentials_not_loaded_from_config_for_different_environment(monkeypatch):
+    # Given
+    clients = {
+        "env_client": model.Client(
+            name="clients/env_client",
+            display_name="Env Client",
+            oauth2_client_id="env-client-id",
+        ),
+        "config_client": model.Client(
+            name="clients/config_client",
+            display_name="Config Client",
+            oauth2_client_id="config-client-id",
+        ),
+    }
+    tokens = {"config-client-id": "config-token"}
+    monkeypatch.setenv("H2O_CLOUD_CLIENT_ENV_CLIENT_TOKEN", "env-token")
+
+    discovery = model.Discovery(clients=clients, environment=_ENVIRONMENT, services={})
+    cfg = config.Config(tokens=tokens, endpoint="https://other.com")
+
+    # When
+    result = load.load_credentials(discovery=discovery, cfg=cfg)
+
+    # Then
+    assert result == {
+        "env_client": model.Credentials(client="env_client", refresh_token="env-token")
     }


### PR DESCRIPTION
This can happen when the discovery endpoint is set explicitly or via env variables.
Such credentials do not work with the target environment anyway.
