### PR TITLE
build: 👷 set `uv` as installer for hatch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ include = ["/src", "/tests", "CHANGELOG.md"]
 [tool.hatch.build.targets.wheel]
 packages = ["src/h2o_discovery"]
 
+[tool.hatch.envs.default]
+installer = "uv"
+
 [[tool.hatch.envs.test.matrix]]
 httpx = ["httpx0.23", "httpx0.24", "httpx0.25", "httpx0.26", "httpx0.27", "httpx0.28"]
 python = ["3.9", "3.10", "3.11", "3.12", "3.13"]


### PR DESCRIPTION
hatch has support for uv https://hatch.pypa.io/dev/how-to/environment/select-installer/

```sh
hatch env remove devtest && hatch run devtest:pytest
```

Takes our ~4s on my machine without uv. With uv its ~1s.

