### PR TITLE
Ensured that we follow redirects (for example from http to https)

### DIFF
--- a/src/h2o_discovery/_internal/client.py
+++ b/src/h2o_discovery/_internal/client.py
@@ -86,7 +86,10 @@ class Client(_BaseClient):
 
     def _client(self) -> httpx.Client:
         return httpx.Client(
-            base_url=self._uri, timeout=self._timeout, verify=self._verify, follow_redirects=self.follow_redirects
+            base_url=self._uri,
+            timeout=self._timeout,
+            verify=self._verify,
+            follow_redirects=self.follow_redirects,
         )
 
 
@@ -163,7 +166,10 @@ class AsyncClient(_BaseClient):
 
     def _client(self) -> httpx.AsyncClient:
         return httpx.AsyncClient(
-            base_url=self._uri, timeout=self._timeout, verify=self._verify, follow_redirects=self.follow_redirects
+            base_url=self._uri,
+            timeout=self._timeout,
+            verify=self._verify,
+            follow_redirects=self.follow_redirects,
         )
 
 

--- a/src/h2o_discovery/_internal/client.py
+++ b/src/h2o_discovery/_internal/client.py
@@ -24,10 +24,11 @@ class _BaseClient:
         uri: str,
         timeout: Optional[datetime.timedelta] = None,
         ssl_context: Optional[ssl.SSLContext] = None,
+        follow_redirects: bool = True,
     ):
         self._uri = uri
         self._verify = ssl_context or ssl.create_default_context()
-
+        self.follow_redirects = follow_redirects
         self._timeout = 5.0
         if timeout is not None:
             self._timeout = timeout.total_seconds()
@@ -85,7 +86,7 @@ class Client(_BaseClient):
 
     def _client(self) -> httpx.Client:
         return httpx.Client(
-            base_url=self._uri, timeout=self._timeout, verify=self._verify
+            base_url=self._uri, timeout=self._timeout, verify=self._verify, follow_redirects=self.follow_redirects
         )
 
 
@@ -162,7 +163,7 @@ class AsyncClient(_BaseClient):
 
     def _client(self) -> httpx.AsyncClient:
         return httpx.AsyncClient(
-            base_url=self._uri, timeout=self._timeout, verify=self._verify
+            base_url=self._uri, timeout=self._timeout, verify=self._verify, follow_redirects=self.follow_redirects
         )
 
 

--- a/tests/_internal/test_client.py
+++ b/tests/_internal/test_client.py
@@ -420,6 +420,7 @@ async def test_async_client_list_links_can_handle_empty_response():
     # Then
     assert links == []
 
+
 @respx.mock
 def test_follows_redirect():
     respx.get("http://test.example.com/v1/environment").mock(
@@ -430,16 +431,16 @@ def test_follows_redirect():
     )
 
     respx.get("https://test.example.com/v1/environment").mock(
-        return_value=httpx.Response(
-            status_code=200,
-            json=ENVIRONMENT_JSON
-        )
+        return_value=httpx.Response(status_code=200, json=ENVIRONMENT_JSON)
     )
 
     client_test = client.Client("http://test.example.com", follow_redirects=True)
     resp = client_test.get_environment()
 
-    assert resp.h2o_cloud_environment== ENVIRONMENT_JSON["environment"]["h2oCloudEnvironment"]
+    assert (
+        resp.h2o_cloud_environment
+        == ENVIRONMENT_JSON["environment"]["h2oCloudEnvironment"]
+    )
 
 
 @respx.mock
@@ -453,15 +454,17 @@ async def test_async_follows_redirect():
     )
 
     respx.get("https://test.example.com/v1/environment").mock(
-        return_value=httpx.Response(
-            status_code=200,
-            json=ENVIRONMENT_JSON
-        )
+        return_value=httpx.Response(status_code=200, json=ENVIRONMENT_JSON)
     )
 
-    client_async_test = client.AsyncClient("http://test.example.com", follow_redirects=True)
+    client_async_test = client.AsyncClient(
+        "http://test.example.com", follow_redirects=True
+    )
     resp = await client_async_test.get_environment()
-    assert resp.h2o_cloud_environment== ENVIRONMENT_JSON["environment"]["h2oCloudEnvironment"]
+    assert (
+        resp.h2o_cloud_environment
+        == ENVIRONMENT_JSON["environment"]["h2oCloudEnvironment"]
+    )
 
 
 def _assert_pagination_api_calls(route):


### PR DESCRIPTION
rellnotes=Updated the client tests to correctly mock HTTP → HTTPS redirects. This ensures follow-redirect behavior is tested reliably and prevents “request not mocked” errors in CI. End users benefit from more stable, fully verified client behavior when connecting to secure endpoints.