### PR TITLE
feat:  Follow redirects by default and allow to disable it

### DIFF
--- a/src/h2o_discovery/_internal/client.py
+++ b/src/h2o_discovery/_internal/client.py
@@ -28,7 +28,7 @@ class _BaseClient:
     ):
         self._uri = uri
         self._verify = ssl_context or ssl.create_default_context()
-        self.follow_redirects = follow_redirects
+        self._follow_redirects = follow_redirects
         self._timeout = 5.0
         if timeout is not None:
             self._timeout = timeout.total_seconds()
@@ -89,7 +89,7 @@ class Client(_BaseClient):
             base_url=self._uri,
             timeout=self._timeout,
             verify=self._verify,
-            follow_redirects=self.follow_redirects,
+            follow_redirects=self._follow_redirects,
         )
 
 
@@ -169,7 +169,7 @@ class AsyncClient(_BaseClient):
             base_url=self._uri,
             timeout=self._timeout,
             verify=self._verify,
-            follow_redirects=self.follow_redirects,
+            follow_redirects=self._follow_redirects,
         )
 
 

--- a/src/h2o_discovery/_internal/client.py
+++ b/src/h2o_discovery/_internal/client.py
@@ -86,7 +86,10 @@ class Client(_BaseClient):
 
     def _client(self) -> httpx.Client:
         return httpx.Client(
-            base_url=self._uri, timeout=self._timeout, verify=self._verify, follow_redirects=self.follow_redirects
+            base_url=self._uri,
+            timeout=self._timeout,
+            verify=self._verify,
+            follow_redirects=self.follow_redirects,
         )
 
 
@@ -163,7 +166,10 @@ class AsyncClient(_BaseClient):
 
     def _client(self) -> httpx.AsyncClient:
         return httpx.AsyncClient(
-            base_url=self._uri, timeout=self._timeout, verify=self._verify, follow_redirects=self.follow_redirects
+            base_url=self._uri,
+            timeout=self._timeout,
+            verify=self._verify,
+            follow_redirects=self.follow_redirects,
         )
 
 

--- a/src/h2o_discovery/_internal/client.py
+++ b/src/h2o_discovery/_internal/client.py
@@ -24,10 +24,11 @@ class _BaseClient:
         uri: str,
         timeout: Optional[datetime.timedelta] = None,
         ssl_context: Optional[ssl.SSLContext] = None,
+        follow_redirects: bool = True,
     ):
         self._uri = uri
         self._verify = ssl_context or ssl.create_default_context()
-
+        self.follow_redirects = follow_redirects
         self._timeout = 5.0
         if timeout is not None:
             self._timeout = timeout.total_seconds()
@@ -85,7 +86,7 @@ class Client(_BaseClient):
 
     def _client(self) -> httpx.Client:
         return httpx.Client(
-            base_url=self._uri, timeout=self._timeout, verify=self._verify
+            base_url=self._uri, timeout=self._timeout, verify=self._verify, follow_redirects=self.follow_redirects
         )
 
 
@@ -162,7 +163,7 @@ class AsyncClient(_BaseClient):
 
     def _client(self) -> httpx.AsyncClient:
         return httpx.AsyncClient(
-            base_url=self._uri, timeout=self._timeout, verify=self._verify
+            base_url=self._uri, timeout=self._timeout, verify=self._verify, follow_redirects=self.follow_redirects
         )
 
 

--- a/tests/_internal/test_client.py
+++ b/tests/_internal/test_client.py
@@ -467,6 +467,43 @@ async def test_async_follows_redirect():
     )
 
 
+@respx.mock
+def test_error_without_using_follow_redirects_true():
+    respx.get("http://test.example.com/v1/environment").mock(
+        return_value=httpx.Response(
+            status_code=301,
+            headers={"Location": "https://test.example.com/v1/environment"},
+        )
+    )
+    client_test = client.Client("http://test.example.com", follow_redirects=False)
+
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        resp = client_test.get_environment()
+        resp.raise_for_status()
+
+    assert exc.value.response.status_code == 301
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_async_error_without_using_follow_redirects_true():
+    respx.get("http://test.example.com/v1/environment").mock(
+        return_value=httpx.Response(
+            status_code=301,
+            headers={"Location": "https://test.example.com/v1/environment"},
+        )
+    )
+
+    client_async_test = client.AsyncClient(
+        "http://test.example.com", follow_redirects=False
+    )
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        resp = await client_async_test.get_environment()
+        resp.raise_for_status()
+
+    assert exc.value.response.status_code == 301
+
+
 def _assert_pagination_api_calls(route):
     assert route.call_count == 3
     assert not route.calls[0].request.url.query

--- a/tests/_internal/test_client.py
+++ b/tests/_internal/test_client.py
@@ -422,21 +422,21 @@ async def test_async_client_list_links_can_handle_empty_response():
 
 
 @respx.mock
-def test_follows_redirect():
-    respx.get("http://test.example.com/v1/environment").mock(
-        return_value=httpx.Response(
-            status_code=301,
-            headers={"Location": "https://test.example.com/v1/environment"},
-        )
+def test_client_follows_redirect():
+    # Given
+    respx.get("http://test.example.com/v1/environment").respond(
+        status_code=301, headers={"Location": "https://test.example.com/v1/environment"}
     )
 
-    respx.get("https://test.example.com/v1/environment").mock(
-        return_value=httpx.Response(status_code=200, json=ENVIRONMENT_JSON)
+    respx.get("https://test.example.com/v1/environment").respond(
+        status_code=200, json=ENVIRONMENT_JSON
     )
-
     client_test = client.Client("http://test.example.com", follow_redirects=True)
+
+    # When
     resp = client_test.get_environment()
 
+    # Then
     assert (
         resp.h2o_cloud_environment
         == ENVIRONMENT_JSON["environment"]["h2oCloudEnvironment"]
@@ -445,22 +445,24 @@ def test_follows_redirect():
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_async_follows_redirect():
-    respx.get("http://test.example.com/v1/environment").mock(
-        return_value=httpx.Response(
-            status_code=301,
-            headers={"Location": "https://test.example.com/v1/environment"},
-        )
+async def test_async_client_follows_redirect():
+    # Given
+    respx.get("http://test.example.com/v1/environment").respond(
+        status_code=301, headers={"Location": "https://test.example.com/v1/environment"}
     )
 
-    respx.get("https://test.example.com/v1/environment").mock(
-        return_value=httpx.Response(status_code=200, json=ENVIRONMENT_JSON)
+    respx.get("https://test.example.com/v1/environment").respond(
+        status_code=200, json=ENVIRONMENT_JSON
     )
 
     client_async_test = client.AsyncClient(
         "http://test.example.com", follow_redirects=True
     )
+
+    # When
     resp = await client_async_test.get_environment()
+
+    # Then
     assert (
         resp.h2o_cloud_environment
         == ENVIRONMENT_JSON["environment"]["h2oCloudEnvironment"]
@@ -468,39 +470,40 @@ async def test_async_follows_redirect():
 
 
 @respx.mock
-def test_error_without_using_follow_redirects_true():
-    respx.get("http://test.example.com/v1/environment").mock(
-        return_value=httpx.Response(
-            status_code=301,
-            headers={"Location": "https://test.example.com/v1/environment"},
-        )
+def test_client_301_redirect_raises_when_follow_redirects_false():
+    # Given
+    respx.get("http://test.example.com/v1/environment").respond(
+        status_code=301, headers={"Location": "https://test.example.com/v1/environment"}
     )
     client_test = client.Client("http://test.example.com", follow_redirects=False)
 
+    # When
     with pytest.raises(httpx.HTTPStatusError) as exc:
         resp = client_test.get_environment()
         resp.raise_for_status()
 
+    # Then
     assert exc.value.response.status_code == 301
 
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_async_error_without_using_follow_redirects_true():
-    respx.get("http://test.example.com/v1/environment").mock(
-        return_value=httpx.Response(
-            status_code=301,
-            headers={"Location": "https://test.example.com/v1/environment"},
-        )
+async def test_async_client_301_redirect_raises_when_follow_redirects_false():
+    # Given
+    respx.get("http://test.example.com/v1/environment").respond(
+        status_code=301, headers={"Location": "https://test.example.com/v1/environment"}
     )
 
     client_async_test = client.AsyncClient(
         "http://test.example.com", follow_redirects=False
     )
+
+    # When
     with pytest.raises(httpx.HTTPStatusError) as exc:
         resp = await client_async_test.get_environment()
         resp.raise_for_status()
 
+    # Then
     assert exc.value.response.status_code == 301
 
 

--- a/tests/_internal/test_client.py
+++ b/tests/_internal/test_client.py
@@ -420,6 +420,7 @@ async def test_async_client_list_links_can_handle_empty_response():
     # Then
     assert links == []
 
+
 @respx.mock
 def test_follows_redirect():
     respx.get("http://test.example.com/v1/environment").mock(
@@ -430,16 +431,16 @@ def test_follows_redirect():
     )
 
     respx.get("https://test.example.com/v1/environment").mock(
-        return_value=httpx.Response(
-            status_code=200,
-            json=ENVIRONMENT_JSON
-        )
+        return_value=httpx.Response(status_code=200, json=ENVIRONMENT_JSON)
     )
 
     client_test = client.Client("http://test.example.com", follow_redirects=True)
     resp = client_test.get_environment()
 
-    assert resp.h2o_cloud_environment== ENVIRONMENT_JSON["environment"]["h2oCloudEnvironment"]
+    assert (
+        resp.h2o_cloud_environment
+        == ENVIRONMENT_JSON["environment"]["h2oCloudEnvironment"]
+    )
 
 
 @respx.mock
@@ -453,15 +454,17 @@ async def test_async_follows_redirect():
     )
 
     respx.get("https://test.example.com/v1/environment").mock(
-        return_value=httpx.Response(
-            status_code=200,
-            json=ENVIRONMENT_JSON
-        )
+        return_value=httpx.Response(status_code=200, json=ENVIRONMENT_JSON)
     )
 
-    client_async_test = client.AsyncClient("http://test.example.com", follow_redirects=True)
+    client_async_test = client.AsyncClient(
+        "http://test.example.com", follow_redirects=True
+    )
     resp = await client_async_test.get_environment()
-    assert resp.h2o_cloud_environment== ENVIRONMENT_JSON["environment"]["h2oCloudEnvironment"]
+    assert (
+        resp.h2o_cloud_environment
+        == ENVIRONMENT_JSON["environment"]["h2oCloudEnvironment"]
+    )
 
 
 def _assert_pagination_api_calls(route):


### PR DESCRIPTION
rellnotes=We now automatically redirect all HTTP requests to HTTPS, ensuring secure communication.
This protects client data and simplifies integration by transparently enforcing encrypted connections.